### PR TITLE
Attaching a Scroll View Aligns its Scroll with Moving the Pull Up Controller

### DIFF
--- a/PullUpController.podspec
+++ b/PullUpController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PullUpController'
-  s.version          = '0.6.0'
+  s.version          = '0.6.1'
   s.summary          = 'Pull up controller with multiple sticky points like in iOS Maps.'
   s.homepage         = 'https://github.com/MarioIannotta/PullUpController'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/PullUpController.podspec
+++ b/PullUpController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PullUpController'
-  s.version          = '0.6.1'
+  s.version          = '0.6.0'
   s.summary          = 'Pull up controller with multiple sticky points like in iOS Maps.'
   s.homepage         = 'https://github.com/MarioIannotta/PullUpController'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -244,12 +244,16 @@ open class PullUpController: UIViewController {
                            customTopOffset: superview.frame.height - initialStickyPointOffset)
     }
     
-    fileprivate func setupPanGenstureRecognizerForInternalScrollView() {
+    fileprivate func setupPanGenstureRecognizerOfInternalScrollView() {
         internalScrollView?.panGestureRecognizer.addTarget(self, action: #selector(handleScrollViewGestureRecognizer(_:)))
     }
     
+    fileprivate func removePanGestureRecognizerOfInternalScrollView() {
+        internalScrollView?.panGestureRecognizer.removeTarget(self, action: #selector(handleScrollViewGestureRecognizer(_:)))
+    }
+    
     private func setupPanGestureRecognizer() {
-        setupPanGenstureRecognizerForInternalScrollView()
+        setupPanGenstureRecognizerOfInternalScrollView()
         panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGestureRecognizer(_:)))
         panGestureRecognizer?.minimumNumberOfTouches = 1
         panGestureRecognizer?.maximumNumberOfTouches = 1
@@ -518,7 +522,7 @@ extension UIScrollView {
     open func attach(to pullUpController: PullUpController) {
         pullUpController.internalScrollView?.detach(from: pullUpController)
         pullUpController.internalScrollView = self
-        pullUpController.setupPanGenstureRecognizerForInternalScrollView()
+        pullUpController.setupPanGenstureRecognizerOfInternalScrollView()
     }
     
     /**
@@ -526,6 +530,7 @@ extension UIScrollView {
      - parameter pullUpController: the pull up controller to be removed from controlling the scroll view.
      */
     open func detach(from pullUpController: PullUpController) {
+        pullUpController.removePanGestureRecognizerOfInternalScrollView()
         pullUpController.internalScrollView = nil
     }
 

--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -244,8 +244,12 @@ open class PullUpController: UIViewController {
                            customTopOffset: superview.frame.height - initialStickyPointOffset)
     }
     
-    private func setupPanGestureRecognizer() {
+    fileprivate func setupPanGenstureRecognizerForInternalScrollView() {
         internalScrollView?.panGestureRecognizer.addTarget(self, action: #selector(handleScrollViewGestureRecognizer(_:)))
+    }
+    
+    private func setupPanGestureRecognizer() {
+        setupPanGenstureRecognizerForInternalScrollView()
         panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGestureRecognizer(_:)))
         panGestureRecognizer?.minimumNumberOfTouches = 1
         panGestureRecognizer?.maximumNumberOfTouches = 1
@@ -513,6 +517,7 @@ extension UIScrollView {
      */
     open func attach(to pullUpController: PullUpController) {
         pullUpController.internalScrollView = self
+        pullUpController.setupPanGenstureRecognizerForInternalScrollView()
     }
     
     /**

--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -516,6 +516,7 @@ extension UIScrollView {
      - parameter pullUpController: the pull up controller to move with the current scroll view content.
      */
     open func attach(to pullUpController: PullUpController) {
+        pullUpController.internalScrollView?.detach(from: pullUpController)
         pullUpController.internalScrollView = self
         pullUpController.setupPanGenstureRecognizerForInternalScrollView()
     }


### PR DESCRIPTION
Hopefully resolves #52 

First of all, thank you very much for this awesome library :)

This is an improvement for attaching scroll views after the `PullUpController` was added to the view controller, so that the scroll view's scroll action will also affect the movement of the `PullUpController`.

This feels like a very naive solution, so please let me know if I'm missing anything.

Thanks!