### PR TITLE
Add missing `didMove(toParent: ..)` call

### DIFF
--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -491,9 +491,14 @@ extension UIViewController {
                 animations: { [weak self] in
                     self?.view.layoutIfNeeded()
                 },
-                completion: completion)
+                completion: { didComplete in
+                    pullUpController.didMove(toParent: self)
+                    completion?(didComplete)
+                }
+            )
         } else {
             view.layoutIfNeeded()
+            pullUpController.didMove(toParent: self)
             completion?(true)
         }
     }

--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -494,6 +494,7 @@ extension UIViewController {
                 completion: completion)
         } else {
             view.layoutIfNeeded()
+            completion?(true)
         }
     }
     
@@ -525,7 +526,7 @@ extension UIViewController {
             pullUpController.willMove(toParent: nil)
             pullUpController.view.removeFromSuperview()
             pullUpController.removeFromParent()
-            completion?(didComplete)
+            completion?(true)
         }
     }
     


### PR DESCRIPTION
**This depends on #73. Will need to rebase after that is merged**

When adding a child view controller, the container view controller implementation is required to call `didMove(toParent:..)` after the child's view is added to the view hierarchy. 

Docs [here](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621405-didmove)
> If you are implementing your own container view controller, it must call the didMove(toParent:) method of the child view controller after the transition to the new controller is complete or, if there is no transition, immediately after calling the addChild(_:) method.